### PR TITLE
Translate French comments in tests

### DIFF
--- a/app/apis/apis_test.py
+++ b/app/apis/apis_test.py
@@ -39,9 +39,9 @@ def mocked_env_vars():
 
 @pytest.fixture(scope="module")
 def get_headers(mocked_env_vars):
-    # Génération d'un token JWT pour un utilisateur fictif
+    # Generate a JWT token for a fictitious user
     token = create_token(user_id="test_user")
-    # Retourne les en-têtes nécessaires
+    # Return the required headers
     return {"Authorization": f"Bearer {token}"}
 
 # Test for the model creation API

--- a/app/common_test.py
+++ b/app/common_test.py
@@ -123,14 +123,14 @@ def test_parse_input_data_file_path_construction():
     file_name = "example.json"
     expected_path = FILES_DIR / file_name
 
-    # This function will replace Path.open. 'self' sera
-    # l'instance de Path utilisée, ce qui nous permet de vérifier le chemin.
+    # This function replaces Path.open. 'self' will be the Path instance used,
+    # allowing us to verify the path.
     def open_side_effect(self, mode="r", encoding=None):
-        # On s'assure que l'instance 'self' correspond au chemin attendu.
+        # Ensure that the 'self' instance matches the expected path.
         assert str(self) == str(expected_path), (
             f"Expected the path to be {expected_path}, got {self}"
         )
-        # On renvoie un Mock de fichier (mock_open) pour simuler la lecture du fichier.
+        # Return a file mock (mock_open) to simulate reading the file.
         return mock_open(read_data='{"test": 123}')()
 
     with patch("pathlib.Path.exists", return_value=True), \

--- a/app/neural_network/nn_siamese_test.py
+++ b/app/neural_network/nn_siamese_test.py
@@ -51,14 +51,14 @@ def test_train_siamese_model_nn():
         target_indices = tokens_to_indices(target_tokens, word2idx)
         transformed_data.append((source_indices, target_indices, score))
     
-    # Entraîner le modèle avec un chemin unique
+    # Train the model using a single path
     nn_model, report = train_siamese_model_nn(
         transformed_data,
         vocab_size,
         num_epochs=5
     )
 
-    # Vérifiez que le modèle est entraîné correctement
+    # Verify that the model is trained correctly
     assert nn_model is not None, "Siamese LSTM model was not trained correctly."
     assert report["final_loss"] is not None, "Loss report should not be None."
 

--- a/app/usecases/gru/usecase_super_train_gru_test.py
+++ b/app/usecases/gru/usecase_super_train_gru_test.py
@@ -6,7 +6,7 @@ from app.services.bdd.models.model_data import ModelData, ModelStatus
 from app.apis.models.gru_training_model_data import GRUTrainingModelData
 from app.usecases.gru.usecase_super_train_gru import SuperTrainGRUUsecaseDto, super_train_model_gru
 
-# ✅ Test principal : entraînement multiple avec succès
+# ✅ Main test: successful multiple training iterations
 @patch('app.usecases.gru.usecase_super_train_gru.train_model_gru')
 @patch('app.usecases.gru.usecase_super_train_gru.mesure_gru')
 def test_super_train_model_gru_success(mock_mesure_gru, mock_train_model_gru, patch_inversify):
@@ -46,18 +46,18 @@ def test_super_train_model_gru_success(mock_mesure_gru, mock_train_model_gru, pa
         n_iterations=3  # Small number of iterations for testing
     ))
 
-    # Vérification que l'entraînement et la mesure ont été appelés plusieurs fois
+    # Verify that training and measurement were called multiple times
     assert mock_train_model_gru.call_count == 3
     assert mock_mesure_gru.call_count == 3
 
-    # Vérification que la meilleure accuracy a bien été enregistrée
+    # Verify that the best accuracy was recorded
     assert result["best_test_accuracy"] == 85.0
     assert result["best_measurement_report"]["average_accuracy"] == 85.0
 
-    # Vérification de l'état final du modèle
+    # Verify the final state of the model
     mock_bdd.update_model.assert_called()
 
-# ✅ Test si le modèle est déjà en train d’être entraîné
+# ✅ Test if the model is already being trained
 def test_super_train_model_gru_model_already_training(patch_inversify):
     """Test the case where the GRU model is already in training mode."""
     mock_inversify, mock_bdd = patch_inversify
@@ -75,7 +75,7 @@ def test_super_train_model_gru_model_already_training(patch_inversify):
             inversify=mock_inversify
         ))
 
-# ✅ Test si une erreur survient pendant l’entraînement
+# ✅ Test if an error occurs during training
 @patch('app.usecases.gru.usecase_super_train_gru.train_model_gru')
 def test_super_train_model_gru_error_during_training(mock_train_model_gru, patch_inversify):
     """Test if an error occurs during the super training process."""
@@ -83,7 +83,7 @@ def test_super_train_model_gru_error_during_training(mock_train_model_gru, patch
     mock_model_data = MagicMock(status=ModelStatus.TRAINED)
     mock_bdd.get_model.return_value = mock_model_data
 
-    # Simulation d'une erreur pendant l'entraînement
+    # Simulate an error during training
     mock_train_model_gru.side_effect = Exception("Training failure")
 
     training_data = [GRUTrainingModelData(category="cat1", tokens=["hello", "world"])]

--- a/app/usecases/siamese/usecase_commons_siamese_test.py
+++ b/app/usecases/siamese/usecase_commons_siamese_test.py
@@ -90,18 +90,18 @@ def test_calculate_word_representation():
     ]
 
     expected_output = {
-        "chat": 44.44,   # 4 occurrences / 9 mots
-        "chien": 33.33,  # 3 occurrences / 9 mots
-        "oiseau": 11.11, # 1 occurrence / 9 mots
-        "souris": 11.11  # 1 occurrence / 9 mots
+        "chat": 44.44,   # 4 occurrences out of 9 words
+        "chien": 33.33,  # 3 occurrences out of 9 words
+        "oiseau": 11.11, # 1 occurrence out of 9 words
+        "souris": 11.11  # 1 occurrence out of 9 words
     }
 
     result = calculate_word_representation(dictionary)
 
-    # Vérification que les clés correspondent
+    # Verify that the keys match
     assert set(result.keys()) == set(expected_output.keys())
 
-    # Vérification des valeurs arrondies
+    # Verify rounded values
     for key in result:
         assert round(result[key], 2) == expected_output[key], f"Mismatch for {key}: expected {expected_output[key]}, got {round(result[key], 2)}"
 

--- a/app/usecases/siamese/usecase_super_train_siamese_test.py
+++ b/app/usecases/siamese/usecase_super_train_siamese_test.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, MagicMock
 from app.services.bdd.models.model_data import ModelData, ModelStatus
 from app.usecases.siamese.usecase_super_train_siamese import SuperTrainSiameseUsecaseDto, super_train_model_siamese
 
-# ✅ Test principal : entraînement multiple avec succès
+# ✅ Main test: successful multiple training iterations
 @patch('app.usecases.siamese.usecase_super_train_siamese.train_model_siamese')
 @patch('app.usecases.siamese.usecase_super_train_siamese.mesure_siamese')
 def test_super_train_model_siamese_success(mock_mesure_siamese, mock_train_model_siamese, patch_inversify):
@@ -45,19 +45,19 @@ def test_super_train_model_siamese_success(mock_mesure_siamese, mock_train_model
         n_iterations=3  # Small number of iterations for testing
     ))
 
-    # Vérification que l'entraînement et la mesure ont été appelés plusieurs fois
+    # Verify that training and measurement were called multiple times
     assert mock_train_model_siamese.call_count == 3
     assert mock_mesure_siamese.call_count == 3
 
-    # Vérification que la meilleure accuracy a bien été enregistrée
+    # Verify that the best accuracy was recorded
     assert result["best_test_accuracy"] == 87.5
     assert result["training_report"]["training_stats"]["final_loss"] == 0.05
     assert result["measurement_report"]["prediction_accuracy_percentage"] == 87.5
 
-    # Vérification de l'état final du modèle
+    # Verify the final state of the model
     mock_bdd.update_model.assert_called()
 
-# ✅ Test si le modèle est déjà en train d’être entraîné
+# ✅ Test if the model is already being trained
 def test_super_train_model_siamese_model_already_training(patch_inversify):
     """Test the case where the Siamese model is already in training mode."""
     mock_inversify, mock_bdd = patch_inversify
@@ -75,7 +75,7 @@ def test_super_train_model_siamese_model_already_training(patch_inversify):
             inversify=mock_inversify
         ))
 
-# ✅ Test si une erreur survient pendant l’entraînement
+# ✅ Test if an error occurs during training
 @patch('app.usecases.siamese.usecase_super_train_siamese.train_model_siamese')
 def test_super_train_model_siamese_error_during_training(mock_train_model_siamese, patch_inversify):
     """Test if an error occurs during the super training process."""
@@ -83,7 +83,7 @@ def test_super_train_model_siamese_error_during_training(mock_train_model_siames
     mock_model_data = MagicMock(status=ModelStatus.TRAINED)
     mock_bdd.get_model.return_value = mock_model_data
 
-    # Simulation d'une erreur pendant l'entraînement
+    # Simulate an error during training
     mock_train_model_siamese.side_effect = Exception("Training failure")
 
     training_data = [(["hello", "world"], ["hi", "planet"], 0.9)]


### PR DESCRIPTION
## Summary
- translate French comments to English in tests
- fix newline at EOF for `apis_test`

## Testing
- `pytest -q` *(fails: ForwardRef._evaluate() missing 1 required keyword-only argument)*

------
https://chatgpt.com/codex/tasks/task_e_6845b8dfe3308325b03d47cbb1f9134f