### PR TITLE
Add embedding model measurement API and sample dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,19 @@ curl -X POST http://localhost/api/thing/search \
     "pieces": 3,
     "floor": 2
   }
-  ```
+```
+
+#### Measure an Embedding Model
+**Endpoint**: `POST /embedding/mesure`
+```bash
+curl -X POST http://localhost/api/embedding/mesure \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <YOUR_TOKEN>" \
+  -d '{
+    "model_name": "puppet-o5",
+    "test_path": "o5_test.json"
+  }'
+```
 
 ### Puppet-o2 (GRU Model)
 - **Type**: Gated Recurrent Unit (GRU)  

--- a/app/apis/embedding_api.py
+++ b/app/apis/embedding_api.py
@@ -10,6 +10,10 @@ from app.usecases.embedding.usecase_train_embedding import train_embedding_useca
 from app.usecases.embedding.usecase_create_embedding import create_embedding_usecase
 from app.usecases.embedding.usecase_encode_embedding import encode_embedding_usecase
 from app.usecases.embedding.usecase_similarity_embedding import similarity_embedding_usecase
+from app.usecases.embedding.usecase_mesure_embedding import (
+    MesureEmbeddingUsecaseDto,
+    mesure_embedding,
+)
 
 embedding_router = APIRouter()
 
@@ -17,6 +21,11 @@ class EmbeddingTrainRequest(BaseModel):
     model_name: str
     vocab_path: str
     trainset_path: str
+
+
+class EmbeddingMesureRequest(BaseModel):
+    model_name: str
+    test_path: str
 
 @embedding_router.post("/embedding/create")
 async def create_embedding_api(
@@ -82,4 +91,24 @@ async def similarity_embedding_api(
         return {"similarity": score}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Similarity computation failed: {str(e)}")
+
+
+@embedding_router.post("/embedding/mesure")
+async def mesure_embedding_api(
+    params: EmbeddingMesureRequest,
+    payload: dict = Depends(verify_access_token),
+):
+    """Measure the embedding model performance on a test dataset."""
+    try:
+        test_data = load_json_file(FILES_DIR / params.test_path)
+        result = mesure_embedding(
+            MesureEmbeddingUsecaseDto(
+                name=params.model_name,
+                test_data=test_data,
+                inversify=get_inversify(),
+            )
+        )
+        return {"status": "ok", "detail": result}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Mesure failed: {str(e)}")
 

--- a/app/usecases/embedding/usecase_mesure_embedding.py
+++ b/app/usecases/embedding/usecase_mesure_embedding.py
@@ -1,0 +1,122 @@
+# app/usecases/embedding/usecase_mesure_embedding.py
+import traceback
+from collections import Counter
+from typing import Any, List, NamedTuple, Dict
+
+import numpy as np
+
+from app.services.logger import logger
+from app.services.bdd.models.model_metrics import MetricsModel
+from app.usecases.embedding.usecase_encode_embedding import encode_embedding_usecase
+from app.usecases.embedding.usecase_similarity_embedding import cosine_similarity
+
+
+class MesureEmbeddingUsecaseDto(NamedTuple):
+    name: str
+    test_data: List[Dict[str, Any]]
+    inversify: Any
+
+
+def mesure_embedding(dto: MesureEmbeddingUsecaseDto) -> Dict[str, Any]:
+    """Measure performance of an embedding model on a test dataset."""
+    try:
+        bdd = dto.inversify.get_bdd()
+        total_tests = len(dto.test_data)
+        correct_predictions = 0
+        similarity_precision: List[float] = []
+        details: List[Dict[str, Any]] = []
+
+        for item in dto.test_data:
+            sent1 = item["sentence1"]
+            sent2 = item["sentence2"]
+            expected = float(item.get("label", 0.0))
+
+            emb1 = encode_embedding_usecase(dto.name, sent1, dto.inversify)
+            emb2 = encode_embedding_usecase(dto.name, sent2, dto.inversify)
+            predicted = cosine_similarity(emb1, emb2)
+            error = abs(predicted - expected)
+            precision = (1 - error) * 100
+            similarity_precision.append(precision)
+            is_correct = error <= 0.1
+            if is_correct:
+                correct_predictions += 1
+            details.append({
+                "sentence1": sent1,
+                "sentence2": sent2,
+                "expected_similarity": expected,
+                "predicted_similarity": predicted,
+                "error": error,
+                "precision_percentage": precision,
+                "is_correct": is_correct,
+            })
+            logger.debug(
+                f"Expected: {expected*100:.1f}%, Predicted: {predicted*100:.1f}%, Error: {error*100:.1f}%"
+            )
+
+        prediction_accuracy = (correct_predictions / total_tests) * 100 if total_tests else 0.0
+        if similarity_precision:
+            avg_precision = float(np.mean(similarity_precision))
+            median_precision = float(np.median(similarity_precision))
+            mode_precision = Counter(similarity_precision).most_common(1)[0][0]
+            range_precision = max(similarity_precision) - min(similarity_precision)
+            variance_precision = float(np.var(similarity_precision))
+            std_dev_precision = float(np.std(similarity_precision))
+            q1 = float(np.percentile(similarity_precision, 25))
+            q3 = float(np.percentile(similarity_precision, 75))
+            coeff_variation = (
+                (std_dev_precision / avg_precision) * 100 if avg_precision != 0 else 0
+            )
+        else:
+            avg_precision = median_precision = mode_precision = 0.0
+            range_precision = variance_precision = std_dev_precision = 0.0
+            q1 = q3 = coeff_variation = 0.0
+
+        report = {
+            "model_name": dto.name,
+            "total_tests": total_tests,
+            "correct_predictions": correct_predictions,
+            "prediction_accuracy_percentage": prediction_accuracy,
+            "avg_similarity_precision_percentage": avg_precision,
+            "median_similarity_precision_percentage": median_precision,
+            "mode_similarity_precision_percentage": mode_precision,
+            "range_similarity_percentage": range_precision,
+            "variance_similarity": variance_precision,
+            "std_dev_similarity": std_dev_precision,
+            "quartile_1": q1,
+            "quartile_3": q3,
+            "coefficient_of_variation_percentage": coeff_variation,
+            "details": details,
+        }
+
+        bdd.save_metrics(
+            MetricsModel(
+                model_name=dto.name,
+                metrics={
+                    "type": "mesure",
+                    "total_tests": total_tests,
+                    "correct_predictions": correct_predictions,
+                    "prediction_accuracy_percentage": prediction_accuracy,
+                    "avg_similarity_precision_percentage": avg_precision,
+                    "median_similarity_precision_percentage": median_precision,
+                    "mode_similarity_precision_percentage": mode_precision,
+                    "range_similarity_percentage": range_precision,
+                    "variance_similarity": variance_precision,
+                    "std_dev_similarity": std_dev_precision,
+                    "quartile_1": q1,
+                    "quartile_3": q3,
+                    "coefficient_of_variation_percentage": coeff_variation,
+                },
+            )
+        )
+
+        logger.info(
+            f"Prediction accuracy: {prediction_accuracy:.2f}% ({correct_predictions}/{total_tests})"
+        )
+        logger.info(f"Average similarity precision: {avg_precision:.2f}%")
+        return report
+
+    except Exception as e:
+        logger.error(
+            f"[mesure_embedding] Error: {str(e)}\n{traceback.format_exc()}"
+        )
+        raise Exception(f"[#mesure_embedding]{str(e)}")

--- a/app/usecases/embedding/usecase_mesure_embedding_test.py
+++ b/app/usecases/embedding/usecase_mesure_embedding_test.py
@@ -1,0 +1,50 @@
+import pytest
+from unittest.mock import patch
+
+from app.usecases.embedding.usecase_mesure_embedding import (
+    MesureEmbeddingUsecaseDto,
+    mesure_embedding,
+)
+
+
+@patch("app.usecases.embedding.usecase_mesure_embedding.encode_embedding_usecase")
+def test_mesure_embedding_success(mock_encode, patch_inversify):
+    mock_inversify, _ = patch_inversify
+
+    # Mock embeddings so cosine similarity returns 1 for first pair and 0 for second
+    mock_encode.side_effect = [
+        [1.0, 0.0], [1.0, 0.0],  # similarity 1.0
+        [1.0, 0.0], [0.0, 1.0],  # similarity 0.0
+    ]
+
+    test_data = [
+        {"sentence1": "hello", "sentence2": "bonjour", "label": 1.0},
+        {"sentence1": "hello", "sentence2": "au revoir", "label": 0.0},
+    ]
+
+    result = mesure_embedding(
+        MesureEmbeddingUsecaseDto(
+            name="puppet-o5",
+            test_data=test_data,
+            inversify=mock_inversify,
+        )
+    )
+
+    assert result["total_tests"] == 2
+    assert result["correct_predictions"] == 2
+    assert result["prediction_accuracy_percentage"] == pytest.approx(100.0)
+
+
+@patch("app.usecases.embedding.usecase_mesure_embedding.encode_embedding_usecase", side_effect=Exception("fail"))
+def test_mesure_embedding_failure(mock_encode, patch_inversify):
+    mock_inversify, _ = patch_inversify
+    test_data = [{"sentence1": "a", "sentence2": "b", "label": 1.0}]
+    with pytest.raises(Exception):
+        mesure_embedding(
+            MesureEmbeddingUsecaseDto(
+                name="puppet-o5",
+                test_data=test_data,
+                inversify=mock_inversify,
+            )
+        )
+

--- a/doc/o5_embedding/o5_embedding.http
+++ b/doc/o5_embedding/o5_embedding.http
@@ -41,3 +41,13 @@ Content-Type: application/json
   "sentence1": "un vélo rouge",
   "sentence2": "un grand chapeau"
 }
+
+### Measure the embedding model
+POST {{host}}/embedding/mesure
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+  "model_name": "puppet-o5",
+  "test_path": "o5_test.json"
+}

--- a/files/o5_test.json
+++ b/files/o5_test.json
@@ -1,0 +1,22 @@
+[
+  {"sentence1": "hello", "sentence2": "bonjour", "label": 1.0},
+  {"sentence1": "goodbye", "sentence2": "au revoir", "label": 1.0},
+  {"sentence1": "thank you", "sentence2": "merci", "label": 1.0},
+  {"sentence1": "yes", "sentence2": "oui", "label": 1.0},
+  {"sentence1": "no", "sentence2": "non", "label": 1.0},
+  {"sentence1": "good morning", "sentence2": "bonjour", "label": 1.0},
+  {"sentence1": "good night", "sentence2": "bonne nuit", "label": 1.0},
+  {"sentence1": "i love you", "sentence2": "je t'aime", "label": 1.0},
+  {"sentence1": "how are you", "sentence2": "comment ça va", "label": 1.0},
+  {"sentence1": "see you soon", "sentence2": "à bientôt", "label": 1.0},
+  {"sentence1": "hello", "sentence2": "bonne nuit", "label": 0.0},
+  {"sentence1": "goodbye", "sentence2": "bonjour", "label": 0.0},
+  {"sentence1": "thank you", "sentence2": "je t'aime", "label": 0.0},
+  {"sentence1": "yes", "sentence2": "non", "label": 0.0},
+  {"sentence1": "no", "sentence2": "oui", "label": 0.0},
+  {"sentence1": "good morning", "sentence2": "je t'aime", "label": 0.0},
+  {"sentence1": "good night", "sentence2": "bonjour", "label": 0.0},
+  {"sentence1": "i love you", "sentence2": "comment ça va", "label": 0.0},
+  {"sentence1": "how are you", "sentence2": "à bientôt", "label": 0.0},
+  {"sentence1": "see you soon", "sentence2": "merci", "label": 0.0}
+]


### PR DESCRIPTION
## Summary
- generate small test dataset `o5_test.json`
- implement embedding measurement usecase
- expose `/embedding/mesure` API endpoint
- document the new endpoint
- add tests for the new usecase

## Testing
- `pytest -q` *(fails: ForwardRef._evaluate() missing required argument)*

------
https://chatgpt.com/codex/tasks/task_e_684685a2e6808325a5cb1c0fbac1c004