### PR TITLE
Handle embedding training status

### DIFF
--- a/app/usecases/embedding/usecase_train_embedding.py
+++ b/app/usecases/embedding/usecase_train_embedding.py
@@ -4,7 +4,10 @@ from typing import Any
 
 from app.services.logger import logger
 from app.services.bdd.models.model_metrics import MetricsModel
-from app.neural_network.nn_embedding import train_embedding_model
+from app.neural_network.nn_embedding import (
+    UniversalEmbeddingModel,
+    train_embedding_model,
+)
 from app.services.bdd.models.model_data import ModelData, ModelStatus
 
 def train_embedding_usecase(
@@ -31,8 +34,22 @@ def train_embedding_usecase(
         bdd = inversify.get_bdd()
         vocab_size = len(vocab)
 
-        logger.info(f"[train_embedding_usecase] Starting training for model: {model_name}")
-        logger.info(f"[train_embedding_usecase] Vocab size: {vocab_size}, Train samples: {len(trainset)}")
+        model = bdd.get_model(model_name, UniversalEmbeddingModel)
+        if not model:
+            raise Exception("Model not found")
+
+        if model.status in (ModelStatus.TRAINING, ModelStatus.SUPER_TRAINING):
+            raise Exception("Model is training")
+
+        model.status = ModelStatus.TRAINING
+        bdd.update_model(model)
+
+        logger.info(
+            f"[train_embedding_usecase] Starting training for model: {model_name}"
+        )
+        logger.info(
+            f"[train_embedding_usecase] Vocab size: {vocab_size}, Train samples: {len(trainset)}"
+        )
 
         nn_model, train_stats = train_embedding_model(
             trainset=trainset,
@@ -41,16 +58,18 @@ def train_embedding_usecase(
             lstm_hidden_dim=lstm_hidden_dim,
             batch_size=batch_size,
             num_epochs=num_epochs,
-            learning_rate=learning_rate
+            learning_rate=learning_rate,
         )
 
-        bdd.update_model(ModelData(
-            name=model_name,
-            neural_network_type="EMBEDDING",
-            status=ModelStatus.TRAINED,
-            glossary=list(vocab.keys()),
-            nn_model=nn_model
-        ))
+        bdd.update_model(
+            ModelData(
+                name=model_name,
+                neural_network_type="EMBEDDING",
+                status=ModelStatus.TRAINED,
+                glossary=list(vocab.keys()),
+                nn_model=nn_model,
+            )
+        )
 
         bdd.save_metrics(MetricsModel(
             model_name=model_name,

--- a/app/usecases/embedding/usecase_train_embedding_test.py
+++ b/app/usecases/embedding/usecase_train_embedding_test.py
@@ -1,0 +1,38 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+from app.usecases.embedding.usecase_train_embedding import train_embedding_usecase
+from app.services.bdd.models.model_data import ModelStatus
+
+
+@patch("app.usecases.embedding.usecase_train_embedding.train_embedding_model")
+def test_train_embedding_usecase_success(mock_train_embedding, patch_inversify):
+    mock_inversify, mock_bdd = patch_inversify
+    mock_model = MagicMock(status=ModelStatus.TRAINED)
+    mock_bdd.get_model.return_value = mock_model
+    mock_nn_model = MagicMock()
+    mock_train_embedding.return_value = (mock_nn_model, {"final_loss": 0.1})
+
+    vocab = {"<PAD>": 0, "<UNK>": 1}
+    trainset = [{"seq1": [0], "seq2": [1], "label": 1.0}]
+
+    result = train_embedding_usecase("model", vocab, trainset, mock_inversify)
+
+    assert result["model"] == "model"
+    assert mock_bdd.update_model.call_count == 2
+    assert mock_bdd.update_model.call_args_list[0][0][0].status == ModelStatus.TRAINING
+    assert mock_bdd.update_model.call_args_list[1][0][0].status == ModelStatus.TRAINED
+
+
+@patch("app.usecases.embedding.usecase_train_embedding.train_embedding_model")
+def test_train_embedding_usecase_already_training(mock_train_embedding, patch_inversify):
+    mock_inversify, mock_bdd = patch_inversify
+    mock_model = MagicMock(status=ModelStatus.TRAINING)
+    mock_bdd.get_model.return_value = mock_model
+
+    vocab = {"<PAD>": 0}
+    trainset = [{"seq1": [0], "seq2": [0], "label": 1.0}]
+
+    with pytest.raises(Exception, match="Model is training"):
+        train_embedding_usecase("model", vocab, trainset, mock_inversify)
+    mock_train_embedding.assert_not_called()


### PR DESCRIPTION
## Summary
- prevent training embedding models already in progress
- add tests for `train_embedding_usecase`
- upgrade pydantic for Python 3.12 compatibility

## Testing
- `pytest app/usecases/embedding/usecase_train_embedding_test.py -q`
- `pytest -q` *(fails: 8 failed, 198 passed, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6846ad709f388325a492cea3c62a1753